### PR TITLE
Resolve viewer from node field (relay pagination etc)

### DIFF
--- a/src/model/viewer.js
+++ b/src/model/viewer.js
@@ -1,0 +1,6 @@
+const viewer = {
+  _type: 'Viewer',
+  id: 'viewer'
+};
+
+export default viewer;

--- a/src/query/query.js
+++ b/src/query/query.js
@@ -1,6 +1,7 @@
 import {forEach} from 'lodash';
 import {fromGlobalId, toGlobalId} from 'graphql-relay';
 import getFieldList from './projection';
+import viewer from '../model/viewer';
 
 function processId({id, _id = id}) {
   // global or mongo id
@@ -68,6 +69,7 @@ function updateOne(Collection, args, info) {
     if (res.ok) {
       return getOne(Collection, {_id}, info);
     }
+
     return null;
   });
 }
@@ -179,8 +181,11 @@ function getFirst(Collection) {
 function getIdFetcher(graffitiModels) {
   return function idFetcher(obj, {id: globalId}, info) {
     const {type, id} = fromGlobalId(globalId);
-    const Collection = graffitiModels[type].model;
-    if (Collection) {
+
+    if (type === 'Viewer') {
+      return viewer;
+    } else if (graffitiModels[type]) {
+      const Collection = graffitiModels[type].model;
       return getOne(Collection, {id}, info);
     }
 

--- a/src/query/query.spec.js
+++ b/src/query/query.spec.js
@@ -77,6 +77,14 @@ describe('query', () => {
       const result = await idFetcher({}, {id});
       expect(result).to.eql(resultObj);
     });
+
+    it('should return the Viewer instance', async function getIdFetcherTest() {
+      const id = toGlobalId('Viewer', 'viewer');
+
+      const idFetcher = getIdFetcher(graffitiModels);
+      const result = await idFetcher({}, {id});
+      expect(result).to.eql({_type: 'Viewer', id: 'viewer'});
+    });
   });
 
   describe('getOneResolver', () => {

--- a/src/schema/schema.spec.js
+++ b/src/schema/schema.spec.js
@@ -17,7 +17,7 @@ import query from '../query';
 import model from '../model';
 import type from '../type';
 
-describe('field', () => {
+describe('schema', () => {
   const types = {
     Qux: new GraphQLObjectType({
       name: 'Qux',
@@ -120,6 +120,13 @@ describe('field', () => {
                   id: {
                     type: new GraphQLNonNull(GraphQLID)
                   }
+                },
+                type: {
+                  _implementations: [
+                    {
+                      name: 'Viewer'
+                    }
+                  ]
                 }
               }
             }

--- a/src/type/type.js
+++ b/src/type/type.js
@@ -29,6 +29,18 @@ const {nodeInterface} = nodeDefinitions(null, (obj) => {
   return obj._type ? types[obj._type] : null;
 });
 
+function addType(name, type) {
+  types[name] = type;
+}
+
+const GraphQLViewer = new GraphQLObjectType({
+  name: 'Viewer',
+  interfaces: [nodeInterface]
+});
+
+// register viewer type
+addType('Viewer', GraphQLViewer);
+
 /**
  * Returns a GraphQL type based on a String representation.
  */
@@ -121,7 +133,7 @@ export default function getType(graffitiModels, {name, description, fields}, roo
 
   // register type
   if (root) {
-    types[name] = GraphQLObjectTypeDefinition;
+    addType(name, GraphQLObjectTypeDefinition);
   }
 
   return GraphQLObjectTypeDefinition;
@@ -163,9 +175,11 @@ function getTypes(graffitiModels) {
 }
 
 export default {
+  GraphQLViewer,
   GraphQLDate,
   GraphQLGeneric,
   getType,
   getTypes,
+  addType,
   nodeInterface
 };


### PR DESCRIPTION
This enables us to request instances of the `Viewer` via the `node` field. This is necessary for whenever relay needs to re-fetch nodes, e.g. during pagination (see https://github.com/hardchor/graffiti-todo/tree/pagination-example). 

Feedback is more than welcome (~~apart from the failing tests and commit message format, which I'll address shortly~~ :white_check_mark:).