### PR TITLE
Adds read support types for objects within a list.

### DIFF
--- a/fixture/user.js
+++ b/fixture/user.js
@@ -39,7 +39,15 @@ const UserSchema = new mongoose.Schema({
     subsub: {
       bar: Number
     }
-  }
+  },
+  subArray: [{
+    foo: String,
+    nums: [Number],
+    brother: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User'
+    }
+  }]
 });
 
 const User = mongoose.model('User', UserSchema);

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -1,4 +1,5 @@
 import {reduce, reduceRight, merge} from 'lodash';
+import mongoose from 'mongoose';
 
 /**
  * @method getField
@@ -62,7 +63,17 @@ function extractPath(schemaPath) {
   return reduceRight(subs, (field, sub, key) => {
     const obj = {};
 
-    if (key === (subs.length - 1)) {
+    if (schemaPath instanceof mongoose.Schema.Types.DocumentArray) {
+      const subSchemaPaths = schemaPath.schema.paths;
+      const fields = extractPaths(subSchemaPaths, {name: sub}); // eslint-disable-line no-use-before-define
+      obj[sub] = {
+        name: sub,
+        nonNull: false,
+        type: 'Array',
+        subtype: 'Object',
+        fields
+      };
+    } else if (key === (subs.length - 1)) {
       obj[sub] = getField(schemaPath);
     } else {
       obj[sub] = {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -127,7 +127,9 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}) {
       // }
     }
 
-    if (!(field.type instanceof GraphQLObjectType) && field.name !== 'id' && !field.name.startsWith('_')) {
+    if (field.type instanceof GraphQLList && field.type.ofType instanceof GraphQLObjectType) {
+      // TODO support objects nested in lists
+    } else if (!(field.type instanceof GraphQLObjectType) && field.name !== 'id' && !field.name.startsWith('_')) {
       inputFields[field.name] = field;
     }
 

--- a/src/type/type.js
+++ b/src/type/type.js
@@ -165,13 +165,16 @@ const resolveReference = {};
  * @param  {Boolean} root
  * @return {GraphQLObjectType}
  */
-export default function getType(graffitiModels, {name, description, fields}, root = true) {
+export default function getType(graffitiModels, {name, description, fields}, path = [], rootType = null) {
+  const root = path.length > 0 ? false : true;
   const graphQLType = {name, description};
+  rootType = rootType || graphQLType;
 
-  // These references has to be resolved when all type definitions are avaiable
+  // These references have to be resolved when all type definitions are avaiable
   resolveReference[graphQLType.name] = resolveReference[graphQLType.name] || {};
   const graphQLTypeFields = reduce(fields, (graphQLFields, {name, description, type, subtype, reference, nonNull, hidden, hooks, fields: subfields}, key) => {
     name = name || key;
+    const newPath = [...path, name];
 
     // Don't add hidden fields to the GraphQLObjectType
     if (hidden || name.startsWith('__')) {
@@ -180,10 +183,13 @@ export default function getType(graffitiModels, {name, description, fields}, roo
 
     const graphQLField = {name, description};
 
-    if (type === 'Array') {
+    if (type === 'Array' && subtype === 'Object') {
+      const fields = subfields;
+      graphQLField.type = new GraphQLList(getType(graffitiModels, {name, description, fields}, newPath, rootType));
+    } else if (type === 'Array') {
       graphQLField.type = new GraphQLList(stringToGraphQLType(subtype));
       if (reference) {
-        resolveReference[graphQLType.name][name] = {
+        resolveReference[rootType.name][name] = {
           name,
           type: reference,
           args: connectionArgs,
@@ -195,13 +201,13 @@ export default function getType(graffitiModels, {name, description, fields}, roo
       }
     } else if (type === 'Object') {
       const fields = subfields;
-      graphQLField.type = getType(graffitiModels, {name, description, fields}, false);
+      graphQLField.type = getType(graffitiModels, {name, description, fields}, newPath, rootType);
     } else {
       graphQLField.type = stringToGraphQLType(type);
     }
 
     if (reference && (graphQLField.type === GraphQLID || graphQLField.type === new GraphQLNonNull(GraphQLID))) {
-      resolveReference[graphQLType.name][name] = {
+      resolveReference[rootType.name][newPath.join('.')] = {
         name,
         type: reference,
         resolve: addHooks((rootValue, args, info) => {
@@ -270,10 +276,29 @@ function getTypes(graffitiModels) {
           field.type = types[field.type];
         }
 
-        return {
-          ...typeFields,
-          [fieldName]: field
-        };
+        // deeply find the path of the field we want to resolve the reference of
+        const path = fieldName.split('.');
+        const newTypeFields = {...typeFields};
+        let parent = newTypeFields;
+        let segment;
+
+        while (path.length > 0) {
+          segment = path.shift();
+
+          if (parent[segment]) {
+            if (parent[segment].type instanceof GraphQLObjectType) {
+              parent = parent[segment].type.getFields();
+            } else if (parent[segment].type instanceof GraphQLList &&
+               parent[segment].type.ofType instanceof GraphQLObjectType) {
+              parent = parent[segment].type.ofType._typeConfig.fields();
+            }
+          }
+        }
+
+        if (path.length === 0) {
+          parent[segment] = field;
+        }
+        return newTypeFields;
       }, getTypeFields(type));
 
       // Add new fields

--- a/src/type/type.spec.js
+++ b/src/type/type.spec.js
@@ -72,8 +72,31 @@ describe('type', () => {
               fields: {
                 bar: {
                   type: 'Number'
+                },
+                sister: {
+                  type: 'ObjectID',
+                  reference: 'User',
+                  description: 'The user\'s sister'
                 }
               }
+            }
+          }
+        },
+        subArray: {
+          type: 'Array',
+          subtype: 'Object',
+          fields: {
+            foo: {
+              type: 'String'
+            },
+            nums: {
+              type: 'Array',
+              subtype: 'Number'
+            },
+            brother: {
+              type: 'ObjectID',
+              reference: 'User',
+              description: 'The user\'s brother'
             }
           }
         }
@@ -96,7 +119,7 @@ describe('type', () => {
 
     it('should specify the fields', () => {
       const result = getType([], user);
-      let fields = result._typeConfig.fields();
+      const fields = result._typeConfig.fields();
       expect(fields).to.containSubset({
         name: {
           name: 'name',
@@ -141,8 +164,8 @@ describe('type', () => {
       });
 
       // sub
-      fields = fields.sub.type._typeConfig.fields();
-      expect(fields).to.containSubset({
+      const subFields = fields.sub.type._typeConfig.fields();
+      expect(subFields).to.containSubset({
         foo: {
           name: 'foo',
           type: GraphQLString
@@ -157,11 +180,33 @@ describe('type', () => {
       });
 
       // subsub
-      fields = fields.subsub.type._typeConfig.fields();
-      expect(fields).to.containSubset({
+      const subsubFields = subFields.subsub.type._typeConfig.fields();
+      expect(subsubFields).to.containSubset({
         bar: {
           name: 'bar',
           type: GraphQLFloat
+        },
+        sister: {
+          name: 'sister',
+          type: GraphQLID,
+          description: 'The user\'s sister'
+        }
+      });
+
+      const subArrayFields = fields.subArray.type.ofType._typeConfig.fields();
+      expect(subArrayFields).to.containSubset({
+        foo: {
+          name: 'foo',
+          type: GraphQLString
+        },
+        nums: {
+          name: 'nums',
+          type: new GraphQLList(GraphQLFloat)
+        },
+        brother: {
+          name: 'brother',
+          type: GraphQLID,
+          description: 'The user\'s brother'
         }
       });
     });
@@ -180,6 +225,8 @@ describe('type', () => {
       const fields = userType._typeConfig.fields();
 
       expect(fields.mother.type).to.be.equal(userType);
+      expect(fields.sub.type._fields.subsub.type._fields.sister.type).to.be.equal(userType);
+      expect(fields.subArray.type.ofType._typeConfig.fields().brother.type).to.be.equal(userType);
 
       // connection type
       const nodeField = fields.friends.type._typeConfig.fields().edges.type.ofType._typeConfig.fields().node;


### PR DESCRIPTION
For example, take this schema:

```javascript
    const PostSchema = new mongoose.Schema({
      title: String,
      authors: [{
        username: String,
        email: String
      }]
    })
```

Before this commit `authors` would be mapped to `GraphQLGeneric`. This commit
generates the appropriate nested types within a `GraphQLList`.

This change only applies to queries. Mutations of objects nested in a list are a TODO.