### PR TITLE
Add support for Embedded Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ import graphql from 'graphql';
 import User from './User';
 
 const options = {
-  mutation: false // mutation fields can be disabled
+  mutation: false, // mutation fields can be disabled
+  allowMongoIDMutation: false // mutation of mongo _id can be enabled
 };
 const schema = getSchema([User], options);
 

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -27,6 +27,10 @@ function getField(schemaPath) {
     nonNull: !!index
   };
 
+  if (schemaPath.enumValues && schemaPath.enumValues.length > 0) {
+    field.enumValues = schemaPath.enumValues;
+  }
+
   // ObjectID ref
   if (ref) {
     field.reference = ref;

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -1,6 +1,8 @@
 import {reduce, reduceRight, merge} from 'lodash';
 import mongoose from 'mongoose';
 
+const embeddedModels = {};
+
 /**
  * @method getField
  * @param schemaPaths
@@ -72,6 +74,18 @@ function extractPath(schemaPath) {
         type: 'Array',
         subtype: 'Object',
         fields
+      };
+    } else if (schemaPath instanceof mongoose.Schema.Types.Embedded) {
+      schemaPath.modelName = schemaPath.schema.options.graphqlTypeName || sub;
+      // embedded model must be unique Instance
+      const embeddedModel = embeddedModels.hasOwnProperty(schemaPath.modelName)
+        ? embeddedModels[schemaPath.modelName]
+        : getModel(schemaPath); // eslint-disable-line no-use-before-define
+
+      embeddedModels[schemaPath.modelName] = embeddedModel;
+      obj[sub] = {
+        ...getField(schemaPath),
+        embeddedModel
       };
     } else if (key === (subs.length - 1)) {
       obj[sub] = getField(schemaPath);

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -126,7 +126,9 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDM
 
     if (field.type instanceof GraphQLList && field.type.ofType instanceof GraphQLObjectType) {
       // TODO support objects nested in lists
-    } else if (!(field.type instanceof GraphQLObjectType) && field.name !== 'id' && field.name !== '__v' && (allowMongoIDMutation || field.name !== '_id')) {
+    } else if (!(field.type instanceof GraphQLObjectType)
+        && field.name !== 'id' && field.name !== '__v'
+        && (allowMongoIDMutation || field.name !== '_id')) {
       inputFields[field.name] = field;
     }
 
@@ -206,10 +208,13 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDM
 /**
  * Returns query and mutation root fields
  * @param  {Array} graffitiModels
- * @param  {{Object, Boolean}} {hooks, mutation}
+ * @param  {{Object, Boolean}} {hooks, mutation, allowMongoIDMutation}
  * @return {Object}
  */
-function getFields(graffitiModels, {hooks = {}, mutation = true, allowMongoIDMutation = false} = {}) {
+function getFields(graffitiModels, {
+    hooks = {}, mutation = true, allowMongoIDMutation = false,
+    customQueries = {}, customMutations = {}
+  } = {}) {
   const types = type.getTypes(graffitiModels);
   const {viewer, singular} = hooks;
 
@@ -246,8 +251,8 @@ function getFields(graffitiModels, {hooks = {}, mutation = true, allowMongoIDMut
       }
     };
   }, {
-    queries: {},
-    mutations: {}
+    queries: customQueries,
+    mutations: customMutations
   });
 
   const RootQuery = new GraphQLObjectType({

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -32,6 +32,7 @@ import query from './../query';
 import {addHooks} from '../utils';
 import viewerInstance from '../model/viewer';
 import {toCollectionName} from 'mongoose/lib/utils';
+import createInputObject from '../type/custom/to-input-object';
 
 const idField = {
   name: 'id',
@@ -115,6 +116,11 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDM
         inputFields[field.name] = {
           name: field.name,
           type: new GraphQLList(GraphQLID)
+        };
+      } else if (field.type.mongooseEmbedded) {
+        inputFields[field.name] = {
+          name: field.name,
+          type: createInputObject(field.type)
         };
       } else {
         inputFields[field.name] = {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -131,7 +131,10 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDM
     }
 
     if (field.type instanceof GraphQLList && field.type.ofType instanceof GraphQLObjectType) {
-      // TODO support objects nested in lists
+      inputFields[field.name] = {
+        name: field.name,
+        type: new GraphQLList(createInputObject(field.type.ofType))
+      };
     } else if (!(field.type instanceof GraphQLObjectType)
         && field.name !== 'id' && field.name !== '__v'
         && (allowMongoIDMutation || field.name !== '_id')) {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -104,7 +104,7 @@ function getConnectionField(graffitiModel, type, hooks = {}) {
   };
 }
 
-function getMutationField(graffitiModel, type, viewer, hooks = {}) {
+function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDMutation) {
   const {name} = type;
   const {mutation} = hooks;
 
@@ -126,7 +126,7 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}) {
 
     if (field.type instanceof GraphQLList && field.type.ofType instanceof GraphQLObjectType) {
       // TODO support objects nested in lists
-    } else if (!(field.type instanceof GraphQLObjectType) && field.name !== 'id' && !field.name.startsWith('_')) {
+    } else if (!(field.type instanceof GraphQLObjectType) && field.name !== 'id' && field.name !== '__v' && (allowMongoIDMutation || field.name !== '_id')) {
       inputFields[field.name] = field;
     }
 
@@ -209,7 +209,7 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}) {
  * @param  {{Object, Boolean}} {hooks, mutation}
  * @return {Object}
  */
-function getFields(graffitiModels, {hooks = {}, mutation = true} = {}) {
+function getFields(graffitiModels, {hooks = {}, mutation = true, allowMongoIDMutation = false} = {}) {
   const types = type.getTypes(graffitiModels);
   const {viewer, singular} = hooks;
 
@@ -242,7 +242,7 @@ function getFields(graffitiModels, {hooks = {}, mutation = true} = {}) {
       },
       mutations: {
         ...mutations,
-        ...getMutationField(graffitiModel, type, viewerField, hooks)
+        ...getMutationField(graffitiModel, type, viewerField, hooks, allowMongoIDMutation)
       }
     };
   }, {

--- a/src/schema/schema.spec.js
+++ b/src/schema/schema.spec.js
@@ -31,6 +31,17 @@ describe('schema', () => {
           type: GraphQLID
         }
       })
+    }),
+    TestQuery: new GraphQLObjectType({
+      name: 'TestQuery',
+      type: GraphQLString,
+      fields: () => ({
+        fetchCount: {
+          name: 'fetchCount',
+          type: GraphQLString,
+          resolve: () => '42'
+        }
+      })
     })
   };
 
@@ -159,6 +170,46 @@ describe('schema', () => {
       expect(schema).instanceOf(GraphQLSchema);
       expect(schema._queryType.name).to.be.equal('RootQuery');
       expect(schema._mutationType).to.be.equal(undefined);
+    });
+
+    it('should return a GraphQL schema with custom queries', () => {
+      const graphQLType = types.TestQuery;
+      const customQueries = {
+        testQuery: {
+          type: graphQLType,
+          args: {
+            id: {
+              type: new GraphQLNonNull(GraphQLID)
+            }
+          }
+        }
+      };
+      const schema = getSchema({}, {customQueries});
+      expect(schema).instanceOf(GraphQLSchema);
+      expect(schema._queryType.name).to.be.equal('RootQuery');
+      expect(schema._mutationType.name).to.be.equal('RootMutation');
+      expect(schema._queryType._fields.testQuery.name).to.be.equal('testQuery');
+      expect(schema._queryType._fields.testQuery.type._fields.fetchCount.resolve()).to.be.equal('42');
+    });
+
+    it('should return a GraphQL schema with custom mutations', () => {
+      const graphQLType = types.TestQuery;
+      const customMutations = {
+        testQuery: {
+          type: graphQLType,
+          args: {
+            id: {
+              type: new GraphQLNonNull(GraphQLID)
+            }
+          }
+        }
+      };
+      const schema = getSchema({}, {customMutations});
+      expect(schema).instanceOf(GraphQLSchema);
+      expect(schema._queryType.name).to.be.equal('RootQuery');
+      expect(schema._mutationType.name).to.be.equal('RootMutation');
+      expect(schema._mutationType._fields.testQuery.name).to.be.equal('testQuery');
+      expect(schema._mutationType._fields.testQuery.type._fields.fetchCount.resolve()).to.be.equal('42');
     });
   });
 });

--- a/src/type/custom/to-input-object.js
+++ b/src/type/custom/to-input-object.js
@@ -1,0 +1,55 @@
+/**
+ * Detailed explanation https://github.com/graphql/graphql-js/issues/312#issuecomment-196169994
+ */
+
+import { nodeInterface } from '../../schema/schema';
+import {
+  GraphQLScalarType,
+  GraphQLInputObjectType,
+  GraphQLEnumType,
+  GraphQLID,
+} from 'graphql';
+
+function createInputObject(type) {
+  return new GraphQLInputObjectType({
+    name: `${type.name}Input`,
+    fields: filterFields(type.getFields(), (field) => (!field.noInputObject)), // eslint-disable-line
+  });
+}
+
+function filterFields(obj, filter) {
+  const result = {};
+  Object.keys(obj).forEach((key) => {
+    if (filter(obj[key])) {
+      result[key] = convertInputObjectField(obj[key]); // eslint-disable-line no-use-before-define
+    }
+  });
+  return result;
+}
+
+function convertInputObjectField(field) {
+  let fieldType = field.type;
+  const wrappers = [];
+
+  while (fieldType.ofType) {
+    wrappers.unshift(fieldType.constructor);
+    fieldType = fieldType.ofType;
+  }
+
+  if (
+    !(fieldType instanceof GraphQLInputObjectType ||
+      fieldType instanceof GraphQLScalarType ||
+      fieldType instanceof GraphQLEnumType
+    )
+  ) {
+    fieldType = fieldType.getInterfaces().includes(nodeInterface)
+      ? GraphQLID
+      : createInputObject(fieldType);
+  }
+
+  fieldType = wrappers.reduce((type, Wrapper) => new Wrapper(type), fieldType);
+
+  return { type: fieldType };
+}
+
+export default createInputObject;

--- a/src/type/type.js
+++ b/src/type/type.js
@@ -78,6 +78,18 @@ function stringToGraphQLType(type) {
 }
 
 /**
+ * Returns a GraphQL Enum type based on a List of Strings
+ * @param  {Array} list
+ * @param  {String} name
+ * @return {Object}
+ */
+function listToGraphQLEnumType(list, name) {
+  const values = {};
+  list.forEach((val) => { values[val] = {value: val}; });
+  return new GraphQLEnumType({ name, values });
+}
+
+/**
  * Extracts the fields of a GraphQL type
  * @param  {GraphQLType} type
  * @return {Object}
@@ -190,7 +202,8 @@ function getType(graffitiModels, {name, description, fields}, path = [], rootTyp
   // These references have to be resolved when all type definitions are avaiable
   resolveReference[graphQLType.name] = resolveReference[graphQLType.name] || {};
   const graphQLTypeFields = reduce(fields, (graphQLFields,
-      {name, description, type, subtype, reference, nonNull, hidden, hooks, fields: subfields, embeddedModel}, key) => {
+      {name, description, type, subtype, reference, nonNull, hidden, hooks,
+       fields: subfields, embeddedModel, enumValues}, key) => {
     name = name || key;
     const newPath = [...path, name];
 
@@ -231,6 +244,8 @@ function getType(graffitiModels, {name, description, fields}, path = [], rootTyp
         : getType(graffitiModels, embeddedModel, ['embedded']);
       type.mongooseEmbedded = true;
       graphQLField.type = type;
+    } else if (enumValues && type === 'String') {
+      graphQLField.type = listToGraphQLEnumType(enumValues, getTypeFieldName(graphQLType.name, `${name}Enum`));
     } else {
       graphQLField.type = stringToGraphQLType(type);
     }

--- a/src/type/type.js
+++ b/src/type/type.js
@@ -84,8 +84,10 @@ function stringToGraphQLType(type) {
  * @return {Object}
  */
 function listToGraphQLEnumType(list, name) {
-  const values = {};
-  list.forEach((val) => { values[val] = {value: val}; });
+  const values = reduce(list, (values, val) => {
+    values[val] = {value: val};
+    return values;
+  }, {});
   return new GraphQLEnumType({ name, values });
 }
 


### PR DESCRIPTION
According to http://mongoosejs.com/docs/subdocs.html#single-embedded

```javascript
export const childSchema = new Schema({ name: 'string' }, {graphqlTypeName: 'Child', _id: false});

export const parentSchema = new Schema({
  child: childSchema
});

export const Parent = mongoose.model('Parent', parentSchema);
```

Add ability to pass `childSchema` to GraphQL. Also was added `graphqlTypeName` for child schema, because it must have Type name.

Mutations <del>not realized yet</del>, but for such field types I add catcher `field.type.mongooseEmbedded`. (realized in https://github.com/RisingStack/graffiti-mongoose/pull/104/commits/2da95bfa0a9dd7070a1197387ff83cc160025e04)


@tothandras review needed, may be your suggest better solution for embedded documents.