### PR TITLE
fix(type): add to input-object ability for self-nesting

### DIFF
--- a/src/type/custom/to-input-object.js
+++ b/src/type/custom/to-input-object.js
@@ -7,14 +7,24 @@ import {
   GraphQLScalarType,
   GraphQLInputObjectType,
   GraphQLEnumType,
-  GraphQLID,
+  GraphQLID
 } from 'graphql';
 
+const cachedTypes = {};
+
 function createInputObject(type) {
-  return new GraphQLInputObjectType({
-    name: `${type.name}Input`,
-    fields: filterFields(type.getFields(), (field) => (!field.noInputObject)), // eslint-disable-line
-  });
+  const typeName = `${type.name}Input`;
+
+  if (!cachedTypes.hasOwnProperty(typeName)) {
+    cachedTypes[typeName] = new GraphQLInputObjectType({
+      name: typeName,
+      fields: {}
+    });
+    cachedTypes[typeName]._typeConfig.fields =
+      () => filterFields(type.getFields(), (field) => (!field.noInputObject)); // eslint-disable-line
+  }
+
+  return cachedTypes[typeName];
 }
 
 function filterFields(obj, filter) {


### PR DESCRIPTION
This patch fix broken tests. Problem was at `to-input-object.js` in nesting of same types in one model (User -> brother, friends).