### PR TITLE
Use functions for custom mutations and queries

### DIFF
--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -220,8 +220,12 @@ function getMutationField(graffitiModel, type, viewer, hooks = {}, allowMongoIDM
  */
 function getFields(graffitiModels, {
     hooks = {}, mutation = true, allowMongoIDMutation = false,
-    customQueries = {}, customMutations = {}
+    customQueries = false, customMutations = false
   } = {}) {
+
+  if (customQueries === false) customQueries = () => {}
+  if (customMutations === false) customMutations = () => {}
+
   const types = type.getTypes(graffitiModels);
   const {viewer, singular} = hooks;
 
@@ -258,8 +262,8 @@ function getFields(graffitiModels, {
       }
     };
   }, {
-    queries: customQueries,
-    mutations: customMutations
+    queries: customQueries(types),
+    mutations: customMutations(types)
   });
 
   const RootQuery = new GraphQLObjectType({


### PR DESCRIPTION
The current customMutations and customQueries are powerful, but the types aren't exposed so the it is impossible to use the generated graphQLTypes on his/her customQueries/Mutations.

example:
```javascript
const customMutations = {
  addMaterialChapter: mutationWithClientMutationId({
    name: 'addMaterialChapter',
    inputFields: {
      id: { type: new GraphQLNonNull(GraphQLID) },
      title: { type: GraphQLString },
      content: { type: GraphQLString },
    },
    outputFields: {
      changedMaterial: { type: ??? }                                // no type
    },
    mutateAndGetPayload: async ({ id, title }) => {
      // resolver
    }
  })
}

export default getSchema([Material], {hooks, customMutations})
```

is not possible since the changedMaterial doesn't have the necessary type, since the type will only be exposed once `getSchema` is called and by then it'd already be too late.

What I propose is to pass in a function for both customMutations and Queries, so that the types can be passed dynamically:

```javascript
const customMutations = (types) => ({
  addMaterialChapter: mutationWithClientMutationId({
    name: 'addMaterialChapter',
    inputFields: {
      //resolve
    },
    outputFields: {
      changedMaterial: { type: types.Material }                     // type obtained from types passed
    },
    mutateAndGetPayload: async ({ id, title }) => {
      //resolve
    }
  })
})
```

I realize this is a breaking change, (and I'm not even sure if the above is actually impossible without my PR), so wanted to see what you think @tothandras . If you think the approach is good I'll write tests for it.