### PR TITLE
Use connections for embedded arrays

### DIFF
--- a/src/type/type.js
+++ b/src/type/type.js
@@ -6,6 +6,7 @@ import {
 import {
   globalIdField,
   connectionArgs,
+  connectionFromArray,
   connectionDefinitions,
   nodeDefinitions
 } from 'graphql-relay';
@@ -220,8 +221,20 @@ function getType(graffitiModels, {name, description, fields}, path = [], rootTyp
       if (subtype === 'Object') {
         const fields = subfields;
         const nestedObjectName = getTypeFieldName(graphQLType.name, name);
-        graphQLField.type = new GraphQLList(
-          getType(graffitiModels, {name: nestedObjectName, description, fields}, newPath, rootType));
+
+        const nestedObjectType = getType(graffitiModels, {name: nestedObjectName, description, fields}, newPath, rootType);
+        const {
+          connectionType: nestedObjectConnection,
+          edgeType: nestedObjectEdge,
+        } = connectionDefinitions({
+          name: nestedObjectName,
+          nodeType: nestedObjectType,
+        });
+
+        graphQLField.type = nestedObjectConnection
+        graphQLField.args = { ...connectionArgs }
+        graphQLField.resolve = 
+          (obj, args, c) => connectionFromArray(obj.chapters, args)
       } else {
         graphQLField.type = new GraphQLList(stringToGraphQLType(subtype));
         if (reference) {


### PR DESCRIPTION
Fixes #117 

Use Relay Connections for arrays of Sub-Documents.

This is a breaking change as it casts **every** array of subdocuments into relay style connections/edges. I figured this is okay as the relay connections can do everything graphqllists can do, but not vice-versa.

I'm not really sure if it is possible to cherry-pick or allow the addition of a sentinel value on the schema to prevent this, but I wasn't able to find any (since we're passing the Schema and not just the type object, it doesn't seem to allow the addition of arbitrary properties).

Again, let me know if you think it's all right and I'll add tests for them.